### PR TITLE
Color extension fix

### DIFF
--- a/lib/src/utils/function/extensions/color_extension.dart
+++ b/lib/src/utils/function/extensions/color_extension.dart
@@ -1,5 +1,5 @@
 part of 'extensions.dart';
 
 extension ColorExtension on Color {
-  String get toSerializerString => value.toString().removeAll('#');
+  String get toSerializerString => value.toString();
 }

--- a/test/src/utils/function/extensions/color_extension_test.dart
+++ b/test/src/utils/function/extensions/color_extension_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:rich_text_editor_controller/src/utils/function/extensions/extensions.dart';
+
+void main() {
+  group('ColorExtension', () {
+    group('toSerializerString', () {
+      test(
+        'returns Serialized String value of color',
+        () async {
+          expect(const Color(0xFF000000).toSerializerString, '4278190080');
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
From my perspective, when you call access ` color.value`, the return type is an integer which is then converted to a string using `value.toString()` in the method above. There's no how we'd end up with '#' in the string which makes the `removeAll('#')` redundant.