### PR TITLE
add tests for extensions

### DIFF
--- a/test/src/utils/function/extensions/iterable_extension_test.dart
+++ b/test/src/utils/function/extensions/iterable_extension_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rich_text_editor_controller/src/utils/function/extensions/extensions.dart';
+
+void main() {
+  group('IterableExtension', () {
+    final Iterable<int> items = [1, 2, 3, 4, 5, 6];
+
+    group('containsWhere', () {
+      test(
+        'returns true if iterable contains test item',
+        () async {
+          const testItem = 1;
+
+          final result = items.containsWhere((item) => item == testItem);
+
+          expect(result, true);
+        },
+      );
+
+      test(
+        'returns false if iterable does not contain test item',
+        () async {
+          const testItem = 8;
+
+          final result = items.containsWhere((item) => item == testItem);
+
+          expect(result, false);
+        },
+      );
+    });
+  });
+}

--- a/test/src/utils/function/extensions/list_extension_test.dart
+++ b/test/src/utils/function/extensions/list_extension_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rich_text_editor_controller/src/utils/function/extensions/extensions.dart';
+
+void main() {
+  group('ListExtension', () {
+    group('firstOrNull', () {
+      test(
+        'returns first item if list is not empty',
+        () async {
+          final List<int> list = [1, 2, 3, 4, 5, 6];
+
+          expect(list.firstOrNull, 1);
+        },
+      );
+
+      test(
+        'returns null if list is empty',
+        () async {
+          final List<int> list = [];
+
+          expect(list.firstOrNull, null);
+        },
+      );
+    });
+
+    group('lastOrNull', () {
+      test(
+        'returns first item if list is not empty',
+        () async {
+          final List<int> list = [1, 2, 3, 4, 5, 6];
+
+          expect(list.lastOrNull, 6);
+        },
+      );
+
+      test(
+        'returns null if list is empty',
+        () async {
+          final List<int> list = [];
+
+          expect(list.lastOrNull, null);
+        },
+      );
+    });
+  });
+}

--- a/test/src/utils/function/extensions/nullable_string_extension_test.dart
+++ b/test/src/utils/function/extensions/nullable_string_extension_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rich_text_editor_controller/src/utils/function/extensions/extensions.dart';
+
+void main() {
+  group('NullableStringExtension', () {
+    group('isNullOrEmpty', () {
+      test(
+        'returns true if string is empty',
+        () async {
+          const String testItem = '';
+
+          expect(testItem.isNullOrEmpty, true);
+        },
+      );
+
+      test(
+        'returns true if string is null',
+        () async {
+          String? testItem;
+
+          expect(testItem.isNullOrEmpty, true);
+        },
+      );
+
+      test(
+        'returns false if string is not null or empty',
+        () async {
+          const testItem = "@developerjamiu";
+
+          expect(testItem.isNullOrEmpty, false);
+        },
+      );
+    });
+  });
+}

--- a/test/src/utils/function/extensions/string_extension_test.dart
+++ b/test/src/utils/function/extensions/string_extension_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rich_text_editor_controller/src/utils/function/extensions/extensions.dart';
+
+void main() {
+  group('StringExtension', () {
+    group('removeAll', () {
+      test(
+        'returns new string with input character removed',
+        () async {
+          const String name = "Th00is i0s an0 e00xamp0l0e";
+
+          expect(name.removeAll('0'), 'This is an example');
+        },
+      );
+    });
+
+    group('chars', () {
+      test(
+        'returns a new list of characters in the string',
+        () async {
+          const String name = "jamiu";
+
+          expect(name.chars, ['j', 'a', 'm', 'i', 'u']);
+        },
+      );
+    });
+  });
+}

--- a/test/src/utils/function/extensions/text_editor_extensions_test.dart
+++ b/test/src/utils/function/extensions/text_editor_extensions_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rich_text_editor_controller/src/utils/function/extensions/extensions.dart';
+
+void main() {
+  group('TextAlignExtension', () {
+    group('toAlignment', () {
+      test(
+        'returns Alignment.centerLeft for input TextAlign.start',
+        () async {
+          const TextAlign textAlign = TextAlign.start;
+
+          expect(textAlign.toAlignment, Alignment.centerLeft);
+        },
+      );
+
+      test(
+        'returns Alignment.centerLeft for input TextAlign.left',
+        () async {
+          const TextAlign textAlign = TextAlign.left;
+
+          expect(textAlign.toAlignment, Alignment.centerLeft);
+        },
+      );
+
+      test(
+        'returns Alignment.centerLeft for input TextAlign.end',
+        () async {
+          const TextAlign textAlign = TextAlign.end;
+
+          expect(textAlign.toAlignment, Alignment.centerRight);
+        },
+      );
+
+      test(
+        'returns Alignment.centerLeft for input TextAlign.right',
+        () async {
+          const TextAlign textAlign = TextAlign.right;
+
+          expect(textAlign.toAlignment, Alignment.centerRight);
+        },
+      );
+
+      test(
+        'returns Alignment.center for input TextAlign.center',
+        () async {
+          const TextAlign textAlign = TextAlign.center;
+
+          expect(textAlign.toAlignment, Alignment.center);
+        },
+      );
+
+      test(
+        'returns Alignment.center for input TextAlign.justify',
+        () async {
+          const TextAlign textAlign = TextAlign.justify;
+
+          expect(textAlign.toAlignment, Alignment.center);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
There's one more extension test (ColorExtension) that I didn't include because I do not currently understand the extension requirement yet.

```
extension ColorExtension on Color {
  String get toSerializerString => value.toString().removeAll('#');
}
```

From my perspective, when you call access color.value, the return type is an interger which is then converted to a string using value.toString() in the method above. There's no how we'd end up with '#' in the string which makes the removeAll('#') redundant.

If I'm right, I've made another pull request to correct that here: https://github.com/folaoluwafemi/rich_text_editor_controller/pull/1